### PR TITLE
remove extra parenthesis in viewport check

### DIFF
--- a/src/vertical-timeline.js
+++ b/src/vertical-timeline.js
@@ -104,7 +104,7 @@
                 // Check elements on scroll
                 $(window).on("scroll", function() {
                     $this.find('.vtimeline-block.vt-'+animateType).each(function() {
-                        if (checkViewport($this)[0]) {
+                        if (checkViewport($this[0])) {
                             $(this).removeClass("vt-"+animateType);
                         }
                     });

--- a/src/vertical-timeline.js
+++ b/src/vertical-timeline.js
@@ -104,7 +104,7 @@
                 // Check elements on scroll
                 $(window).on("scroll", function() {
                     $this.find('.vtimeline-block.vt-'+animateType).each(function() {
-                        if (checkViewport($this[0])) {
+                        if (checkViewport($(this)[0])) {
                             $(this).removeClass("vt-"+animateType);
                         }
                     });

--- a/src/vertical-timeline.js
+++ b/src/vertical-timeline.js
@@ -104,7 +104,7 @@
                 // Check elements on scroll
                 $(window).on("scroll", function() {
                     $this.find('.vtimeline-block.vt-'+animateType).each(function() {
-                        if (checkViewport($this)[0])) {
+                        if (checkViewport($this)[0]) {
                             $(this).removeClass("vt-"+animateType);
                         }
                     });


### PR DESCRIPTION
Hi and thanks for your timeline plugin, 
While i was testing it, i saw an alert in console, just an extra parenthesis, here is the correction.


